### PR TITLE
Make VaultProvider use API version 1

### DIFF
--- a/src/main/java/no/nav/kafkaconnect/vault/VaultUtil.java
+++ b/src/main/java/no/nav/kafkaconnect/vault/VaultUtil.java
@@ -64,6 +64,7 @@ public class VaultUtil {
         VaultConfig vaultConfig = null;
         try {
             vaultConfig = new VaultConfig()
+                    .engineVersion(1)
                     .address(getPropertyOrDefault("VAULT_ADDR", "https://vault.adeo.no"))
                     .token(getVaultToken())
                     .openTimeout(5)


### PR DESCRIPTION
The vault driver lib has a issue with vault resource pathing ref:
https://github.com/BetterCloud/vault-java-driver/pull/189
Forcing use of version 1, which is the version on the resources nada-kafka-conenct uses atm, seems to solve the issue.